### PR TITLE
Initial stab at "dry-run" support

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -32,6 +32,7 @@
         envoy_ext_authz_grpc:
             addr: :9191
             query: data.istio.authz.allow
+            dry-run: false
     ```
 
 6. Run OPA

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -50,8 +50,8 @@ type evalResult struct {
 func Validate(m *plugins.Manager, bs []byte) (*Config, error) {
 
 	cfg := Config{
-		Addr:  defaultAddr,
-		Query: defaultQuery,
+		Addr:   defaultAddr,
+		Query:  defaultQuery,
 		DryRun: defaultDryRun,
 	}
 
@@ -118,8 +118,8 @@ func (p *envoyExtAuthzGrpcServer) listen() {
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"addr":  p.cfg.Addr,
-		"query": p.cfg.Query,
+		"addr":    p.cfg.Addr,
+		"query":   p.cfg.Query,
 		"dry-run": p.cfg.DryRun,
 	}).Infof("Starting gRPC server.")
 
@@ -213,10 +213,10 @@ func (p *envoyExtAuthzGrpcServer) eval(ctx context.Context, input ast.Value, opt
 		result.txnID = txn.ID()
 
 		logrus.WithFields(logrus.Fields{
-			"input": input,
-			"query": p.cfg.Query,
+			"input":   input,
+			"query":   p.cfg.Query,
 			"dry-run": p.cfg.DryRun,
-			"txn":   result.txnID,
+			"txn":     result.txnID,
 		}).Infof("Executing policy query.")
 
 		opts = append(opts,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -161,7 +161,7 @@ func (p *envoyExtAuthzGrpcServer) Check(ctx ctx.Context, req *ext_authz.CheckReq
 	status := int32(google_rpc.PERMISSION_DENIED)
 
 	var allow bool
-	allow, err = strconv.ParseBool(result.decision)
+	allow, _ = strconv.ParseBool(result.decision)
 	if p.cfg.DryRun || allow {
 		status = int32(google_rpc.OK)
 	}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -331,6 +331,7 @@ func testAuthzServer(customLogger plugins.Plugin) *envoyExtAuthzGrpcServer {
 		cfg: Config{
 			Addr:        ":50052",
 			Query:       query,
+			DryRun:      false,
 			parsedQuery: parsedQuery,
 		},
 		manager: m,


### PR DESCRIPTION
Initial stab at supporting dry-run mode in the opa-grpc plugin, which defaults to false

If this is set to true, the grpc layer will unconditionally return true, regardless of what the query result was. This will be used in conjunction with console decision logging to query a whole package (e.g. data.mypackage (instead of only supporting boolean like data.mypackage.allow)) so that full context of what led to the decision can be logged.

This will likely only be a short-term strategy, until something like open-policy-agent/opa#1508 is addressed, for two reasons:

We are at the very first stage of trying to roll out this infrastructure, and it's good to be running in this "shadow" mode where we allow no matter what, but we log what we would have done
Once we have some mileage on the infrastructure and open-policy-agent/opa#1508 is addressed, we can have more confidence in allowing actual decisions to be returned while providing the context in response headers, and we can also consider rolling out decision changes in a "canary-like" fashion wherein we roll out new policies to a light weighted percentage of requests.