### PR TITLE
Configure the plugin to log in json format

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -50,6 +50,9 @@ type evalResult struct {
 // instantiate the plugin.
 func Validate(m *plugins.Manager, bs []byte) (*Config, error) {
 
+	// Default to logging consistently with the default in Opa server
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+
 	cfg := Config{
 		Addr:   defaultAddr,
 		Query:  defaultQuery,


### PR DESCRIPTION
While waiting for https://github.com/open-policy-agent/opa/issues/1580, it makes sense to just change the default to json, since that's what Opa's default is anyway, and that's what we'd plan to use anyway.

```
/opt/opa/bin/opa --plugin-dir /opt/opa/plugins/ run --config-file /opt/opa/config.yaml --server
{"addrs":[":8181"],"insecure_addr":"","level":"info","msg":"Initializing server.","time":"2019-07-24T00:08:53Z"}
{"addr":":9191","dry-run":false,"level":"info","msg":"Starting gRPC server.","query":"data.envoy.authz.allow","time":"2019-07-24T00:08:53Z"}
{"level":"info","msg":"Shutting down...","time":"2019-07-24T00:08:55Z"}
{"level":"info","msg":"Server shutdown.","time":"2019-07-24T00:08:55Z"}
```