### PR TITLE
Log policy query and decision results to Info level so that it shows …

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -238,7 +238,7 @@ func (p *envoyExtAuthzGrpcServer) Check(ctx ctx.Context, req *ext_authz.CheckReq
 		"txn":                 result.txnID,
 		"metrics":             result.metrics.All(),
 		"total_decision_time": time.Since(start),
-	}).Debugf("Returning policy decision.")
+	}).Infof("Returning policy decision.")
 
 	// If dry-run mode, override the Status code to unconditionally Allow the request
 	// DecisionLogging should reflect what "would" have happened
@@ -279,7 +279,7 @@ func (p *envoyExtAuthzGrpcServer) eval(ctx context.Context, input ast.Value, opt
 			"query":   p.cfg.Query,
 			"dry-run": p.cfg.DryRun,
 			"txn":     result.txnID,
-		}).Debugf("Executing policy query.")
+		}).Infof("Executing policy query.")
 
 		opts = append(opts,
 			rego.Metrics(result.metrics),


### PR DESCRIPTION
…up for debugging.

Originally I moved this to `Debug` level, but it turns out that due to https://github.com/open-policy-agent/opa/issues/1580 we can't even toggle this information e.g. for debugging. So for now, let's go back to the upstream behavior of logging these messages to `Info`, so that they show up in our environment.